### PR TITLE
fix: leading blank space

### DIFF
--- a/transcribe_from_files.py
+++ b/transcribe_from_files.py
@@ -48,7 +48,7 @@ def transcribe_audios(audio_files, model_size='medium', output_dir='transcripts'
                 if url:
                     f.write(f"source: {url}\n"+"-"*20+'\n')
                 for segment in result["segments"]:
-                    f.write(segment["text"] + "\n")
+                    f.write(segment["text"].strip() + "\n")
             print(f"Transcription saved to: {transcript_file}")
             
         except Exception as e:


### PR DESCRIPTION
Whisper's segment["text"] often contains leading and trailing whitespace, which was being preserved when writing to the transcript files.